### PR TITLE
Fix how the project description is viewed in pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ setup(
     url='https://github.com/gsakkis/pytrie/',
     description='A pure Python implementation of the trie data structure.',
     long_description=open('README.md').read(),
+    long_description_content_type='text/markdown',
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',


### PR DESCRIPTION
This explicitly sets the content type of the description to markdown, so that it is properly rendered in pypi.org